### PR TITLE
Fix XSS potential with server rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "redux",
     "react-router",
     "universal webapp"
-   ],
+  ],
   "devDependencies": {
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",
@@ -80,6 +80,7 @@
     "react-router": "^1.0.0",
     "redux": "^3.0.2",
     "redux-simple-router": "2.0.3",
-    "redux-thunk": "^1.0.0"
+    "redux-thunk": "^1.0.0",
+    "safer-stringify": "0.0.1"
   }
 }

--- a/src/server/renderRoute.js
+++ b/src/server/renderRoute.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { RoutingContext, match } from 'react-router';
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
+import saferStringify from 'safer-stringify';
 import routes from '../common/routes';
 import configureStore from '../common/store/configureStore';
 
@@ -45,7 +46,7 @@ function renderFullPage(html, initialData) {
       <title>Votes as a Service</title>
       <link rel="stylesheet" href="/tetra.css">
 <script>
-  window.__INITIAL_STATE__ = ${JSON.stringify(initialData)};
+  window.__INITIAL_STATE__ = ${saferStringify(initialData)};
 </script>
   </head>
 


### PR DESCRIPTION
Adding a vote (or title) with `</script>` will end the script tag in the
`<head>` for `__INITIAL_STATE__`.  Everything after that is just HTML,
so it's possible to add a further `<script>` tag to load / set external
JavaScript running in the context of the page.

To see the issue, add a choice with the vote text
`Hello world </script><script>alert('Hi there')</script>`

Then go to the page that displays the vote options. Refresh the page,
and observe the 'Hi there' alert box.

This change uses the safer-stringify npm package to escape the
`</script>`.
