### PR TITLE
Fix prerender issue for new votes

### DIFF
--- a/src/common/backend/convertVote.js
+++ b/src/common/backend/convertVote.js
@@ -2,7 +2,7 @@ export default function convertVote(basicVote) {
   const totalVotes = basicVote.choices.reduce((prev, curr) => prev + curr.count, 0);
 
   const convertedChoices = basicVote.choices.map((choice) => ({
-    percent: choice.count * (100 / totalVotes),
+    percent: choice.count * (100 / totalVotes) || 0,
     ...choice
   }));
 

--- a/src/common/components/VotingComponent.js
+++ b/src/common/components/VotingComponent.js
@@ -22,7 +22,6 @@ export default class VotingComponent extends React.Component {
           {vote.choices.map((choice) =>
             <ChoiceBar key={choice.id}
                        onClickHandler={()=>onRegisterChoice(choice)}
-                       percent={choice.count * (100 / vote.totalVotes)}
               {...choice} />
           )}
         </div>


### PR DESCRIPTION
When a new vote is created, the Choice gets a `percent` property, which
the first time results in `null` (or possibly `NaN`), because it does a
`100 / totalVotes`, which is a divide by zero.

This ends up with the vote getting a `width:null%` or `width:NaN%`
depending on server or client, which results in the prerender checksum
not matching.

This commit fixes the percent, so initially, it will be 0%, and removes
the extra `percent` prop from the ChoiceBar in VotingComponent, as it is
then overridden by the `choice.percent` property (due to the
`{...choice}`).
